### PR TITLE
add ability to pull in data from shared symphony directly from composer.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ a text parser that will attempt to export a text encoded composer symphony, to w
 REQUIREMENTS
 needs python3
 pip3 install edn_format
+pip3 install requests
 
 
 
@@ -26,6 +27,9 @@ python3 parser.py -i infile
 	will just print human readable output to the screen
 
 infile: the file that contains the text encoded symphony 
+
+	you can now use the -u option when specifying an infile. This will cause it to treat the infile as a symphony url and it will then pull the data down from composer. 
+
 outfile: the file you want the parsed output to go to
 quantconnect: the output mode style
 	eventual, hopeful, supported output style modes: quantconnect, vectorbt, tradingview, thinkscript

--- a/parser.py
+++ b/parser.py
@@ -12,27 +12,33 @@ thinkscript
 
 
 '''
+import string
 import edn_format
 import argparse
 import json
 import sys
-
+import requests
+import re
 
 
 class InFileReader:
     
-    def __init__(self, filePath):
+    def __init__(self, filePath :string, fileData :string):
         self.filePath = filePath
+        self.file_contents_string = fileData
         self.data = None
         return
         
         
     def readFile(self):
-        with open(self.filePath, "r") as infile:
-            self.file_contents_string = infile.read()
+        if self.file_contents_string == None:
+            with open(self.filePath, "r") as infile:
+                self.file_contents_string = infile.read()
         #  'inputFile.edn'
-        data_with_wrapping_string_removed = json.load(open(self.filePath, 'r'))
-        self.data = edn_format.loads(data_with_wrapping_string_removed)
+            data_with_wrapping_string_removed = json.load(self.file_contents_string)
+            self.data = edn_format.loads(data_with_wrapping_string_removed)
+        else:
+            self.data = edn_format.loads(self.file_contents_string)
         #>>> edn_format.dumps({1, 2, 3})
         #'#{1 2 3}'
         
@@ -123,13 +129,27 @@ class OutfileVectorBt(OutfileBase):
 def main()-> int:
     parser = argparse.ArgumentParser(description='Composer Symphony text parser')
     parser.add_argument('-i','--infile', dest="infile", action="store", help=' input file we read the symphony text from.  full path please', required=True)
+    parser.add_argument('-u', '--url', action="store_true", help="specifies that the input file path is actually the url to a shared, public symphony on composer.trade")
     parser.add_argument('-o','--outfile', dest="outfile", action="store", default="OUTFILE", help=' output file to save the parsed text to.  if not given, will use stdout', required=False)
     parser.add_argument('-m','--mode', dest="mode", action="store", default="human", help=' output parsing mode to use.  if none given, will parse for "human readable output".  modes are: quantconnect, vectorbt, tradingview, thinkscript', required=False)
     args = vars(parser.parse_args())
 
+    if args['url'] == True:
+        #todo move to request this from the composer site instead of hardcoding
+        composerConfig = {
+                "projectId" : "leverheads-278521",
+                "databaseName" : "(default)"
+            }
+        m = re.search('\/symphony\/([^\/]+)', args["infile"])
+        symphId = m.groups(1)[0]
+        symphReq = requests.get(f'https://firestore.googleapis.com/v1/projects/{composerConfig["projectId"]}/databases/{composerConfig["databaseName"]}/documents/symphony/{symphId}')
+        resp = json.loads(symphReq.text)
+  
+        inFileParser = InFileReader(None, resp['fields']['latest_version_edn']['stringValue'])
+    else:
+        print(args["infile"])
+        inFileParser = InFileReader(args["infile"], None)
     
-    print(args["infile"])
-    inFileParser = InFileReader(args["infile"])
     inFileParser.readFile()
     
     


### PR DESCRIPTION
I've added a new optional argument -u / --url. This option causes the parser to treat the infile arg as the url of a shared, public symphony on Composer.trade. It will then download the symphony directly and pull in the correct data. I've changed the constructor and the readFile methods on the InFileReader object to support this. 