### PR TITLE
fix(lib): even more weighting fixes (Core v3)

### DIFF
--- a/lib/logic.py
+++ b/lib/logic.py
@@ -121,31 +121,32 @@ def get_ticker_of_asset_node(node) -> str:
 class NodeBranchState:
     weight: float  # do not read this on :wt-* nodes, behavior not guaranteed
     branch_path_ids: typing.List[str]
-    node_type: str
-    node: typing.Optional[dict] = None
+    parent_nodes: typing.List[dict]
 
 
 def build_node_branch_state_from_root_node(node) -> NodeBranchState:
-    return NodeBranchState(1, [node[":id"]], ":root", node)
+    return NodeBranchState(1, [node[":id"]], [node])
 
 
 def extract_weight_factor(parent_node_branch_state: NodeBranchState, node) -> float:
     # Do not care about :weight if parent type is not a specific node type (UI leaves this strewn everywhere)
     weight = 1
 
+    parent_node_type = parent_node_branch_state.parent_nodes[-1][":step"]
+
     # :wt-cash-specified parent means :weight is specified on this node
-    if parent_node_branch_state.node_type == ":wt-cash-specified" and ":weight" in node:
+    if parent_node_type == ":wt-cash-specified" and ":weight" in node:
         weight *= int(node[":weight"][":num"]) / int(node[":weight"][":den"])
 
     # :wt-cash-equal parent means apply equal % across all siblings of this node
-    if parent_node_branch_state.node_type == ":wt-cash-equal":
-        if parent_node_branch_state.node:
-            weight /= len(get_node_children(parent_node_branch_state.node))
+    if parent_node_type == ":wt-cash-equal":
+        weight /= len(get_node_children(
+            parent_node_branch_state.parent_nodes[-1]))
 
     # :filter parent means apply equal % across :select-n of parent
-    if parent_node_branch_state.node_type == ":filter":
-        if parent_node_branch_state.node:  # always true at this point
-            weight /= int(parent_node_branch_state.node.get(":select-n", 1))
+    if parent_node_type == ":filter":
+        weight /= int(
+            parent_node_branch_state.parent_nodes[-1].get(":select-n", 1))
 
     # :wt-inverse-vol cannot be computed here, theoretical max is 100%
     # :wt-marketcap cannot be computed here, theoretical max is 100%
@@ -160,9 +161,7 @@ def extract_weight_factor(parent_node_branch_state: NodeBranchState, node) -> fl
 def advance_branch_state(parent_node_branch_state: NodeBranchState, node) -> NodeBranchState:
     current_node_branch_state = copy.deepcopy(parent_node_branch_state)
 
-    if node[":step"] != ":group":
-        current_node_branch_state.node_type = node[":step"]
-        current_node_branch_state.node = node
+    current_node_branch_state.parent_nodes.append(node)
 
     if is_if_child_node(node):
         current_node_branch_state.branch_path_ids.append(node[":id"])

--- a/lib/transpilers.py
+++ b/lib/transpilers.py
@@ -84,10 +84,13 @@ class VectorBTTranspiler():
 def main():
     from . import symphony_object, get_backtest_data
 
-    symphony_id = "sB0QNjnVjjCQdIpptNjQ"
+    symphony_id = "KvA0KYc57MQSyykdWcFs"
     symphony = symphony_object.get_symphony(symphony_id)
     root_node = symphony_object.extract_root_node_from_symphony_response(
         symphony)
+
+    print(HumanTextTranspiler.convert_to_string(root_node))
+    print(VectorBTTranspiler.convert_to_string(root_node))
 
     tickers = traversers.collect_referenced_assets(root_node)
 
@@ -116,6 +119,3 @@ def main():
     for branch_id in branches_with_failed_allocation_days:
         print(f"  -> id={branch_id}")
         print(allocations_aligned[branch_tracker_aligned[branch_id] == 1])
-
-    print(HumanTextTranspiler.convert_to_string(root_node))
-    print(VectorBTTranspiler.convert_to_string(root_node))


### PR DESCRIPTION

My last PR introduced a regression, this PR fixes. Here's some test cases I tried out (not automated):

Link | Core v1 | Core v2 | Core v3
-- | -- | -- | --
KvA0KYc57MQSyykdWcFs | ✅ | ✅ | ✅
nvRuAlVoZXaBJZPpLR3S | 💥 conditionless | ✅ | ✅
l4b6WCajCf1jRWwV9msg | ✅ | ✅ | ✅
637WBkGjiqHhZ7H57r5Z | ✅ | ✅ | ✅
sB0QNjnVjjCQdIpptNjQ | ✅ | ✅ | ✅
2XE43Kcoqa0uLSOBuN3q | ✅ | 💥 group re-applies weight | ✅ 
AqYAspTiGFaTDP5cTSIv | 💥 no inverse vol | 💥 undiagnosed (chonk) | ✅ 
n4dUwjxHLcjwSnwpSfTv | 💥 undiagnosed | 💥 implied equal weight | 💥 implied equal weight

For that one remaining issue, "implied equal weight", I want to put in a warning against that instead of supporting it. Look at this:

![image](https://user-images.githubusercontent.com/17038886/199082086-0b4bb64d-68d3-40f6-a6f2-a32f05e30949.png)

How are these supposed to be weighted? Sure, go look at the weight node above that, but it is somewhat ambiguous. Would advise the builder to make it explicit, but that's a later PR.