### PR TITLE
add support for backtest end date

### DIFF
--- a/lib/symphony_backtest.py
+++ b/lib/symphony_backtest.py
@@ -27,16 +27,20 @@ def date_to_epoch_days(day: datetime.date) -> int:
 assert epoch_days_to_date(19289) == datetime.date(2022, 10, 24)
 
 
-def get_composer_backtest_results(symphony_id: str, start_date: datetime.date) -> dict:
-    epoch_days = date_to_epoch_days(start_date)
+def get_composer_backtest_results(symphony_id: str, start_date: datetime.date, end_date: typing.Union[datetime.date,None]=None) -> dict:
+    start_epoch_days = date_to_epoch_days(start_date)
     utc_today = datetime.datetime.now().astimezone(UTC_TIMEZONE).date()
-
     payload = "{:uid nil, :start-date-in-epoch-days START_DATE_EPOCH_DAYS, :capital 10000, :apply-taf-fee? true, :symphony-benchmarks [], :slippage-percent 0.0005, :apply-reg-fee? true, :symphony \"SYMPHONY_ID_GOES_HERE\", :ticker-benchmarks []}"
+    if end_date:
+        end_epoch_days = date_to_epoch_days(end_date)
+        payload = "{:uid nil, :start-date-in-epoch-days START_DATE_EPOCH_DAYS, :end-date-in-epoch-days END_DATE_EPOCH_DAYS, :capital 10000, :apply-taf-fee? true, :symphony-benchmarks [], :slippage-percent 0.0005, :apply-reg-fee? true, :symphony \"SYMPHONY_ID_GOES_HERE\", :ticker-benchmarks []}"
+        payload = payload.replace("END_DATE_EPOCH_DAYS", str(end_epoch_days))
     payload = payload.replace("SYMPHONY_ID_GOES_HERE", symphony_id)
-    payload = payload.replace("START_DATE_EPOCH_DAYS", str(epoch_days))
+    payload = payload.replace("START_DATE_EPOCH_DAYS", str(start_epoch_days))
+
 
     print(
-        f"Fetching backtest results for {symphony_id} from {start_date} to {utc_today}...")
+        f"Fetching backtest results for {symphony_id} from {start_date} to {end_date if end_date else utc_today}...")
 
     tries_remaining = 3
     response = None


### PR DESCRIPTION
This change adds backend support for specifying a custom end date when running backtests, while not breaking the notebooks that have yet to implement this feature.